### PR TITLE
Port `DeviceUtils` to provide device specific wifi warning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,12 @@ androidx-compose = "2025.01.01"
 androidx-core = "1.15.0"
 androidx-fragment = "1.8.5"
 androidx-mediarouter = "1.7.0"
+androidx-test-core = "1.6.1"
+androidx-test-ext-junit = "1.2.1"
 detekt = "1.23.7"
+junit = "4.13.2"
 kotlin = "2.1.10"
+robolectric = "4.14.1"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity" }
@@ -21,6 +25,11 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "androidx-fragment" }
 androidx-mediarouter = { group = "androidx.mediarouter", name = "mediarouter", version.ref = "androidx-mediarouter" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidx-test-core" }
+androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -37,6 +39,16 @@ android {
     lint {
         disable.add("RestrictedApi")
     }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {
@@ -48,4 +60,10 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.core)
     implementation(libs.androidx.mediarouter)
+
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.ext.junit)
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.robolectric)
 }

--- a/lib/src/main/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtils.kt
+++ b/lib/src/main/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtils.kt
@@ -1,0 +1,84 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.content.res.Configuration.SCREENLAYOUT_SIZE_LARGE
+import android.content.res.Configuration.SCREENLAYOUT_SIZE_MASK
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.os.Build
+import androidx.annotation.Dimension
+import androidx.core.content.getSystemService
+import androidx.mediarouter.R
+
+// Kotlin port of MediaRouter internal DeviceUtils class.
+internal object DeviceUtils {
+    private const val FEATURE_TV_1 = "com.google.android.tv"
+
+    @Dimension(unit = Dimension.DP)
+    private const val SEVEN_INCH_TABLET_MINIMUM_SCREEN_WIDTH_DP = 600
+
+    fun getDialogChooserWifiWarningDescription(context: Context): String {
+        return if (isPhone(context) || isFoldable(context)) {
+            context.getString(R.string.mr_chooser_wifi_warning_description_phone)
+        } else if (isTablet(context) || isSevenInchTablet(context)) {
+            context.getString(R.string.mr_chooser_wifi_warning_description_tablet)
+        } else if (isTv(context)) {
+            context.getString(R.string.mr_chooser_wifi_warning_description_tv)
+        } else if (isWearable(context)) {
+            context.getString(R.string.mr_chooser_wifi_warning_description_watch)
+        } else if (isAuto(context)) {
+            context.getString(R.string.mr_chooser_wifi_warning_description_car)
+        } else {
+            context.getString(R.string.mr_chooser_wifi_warning_description_unknown)
+        }
+    }
+
+    private fun isPhone(context: Context): Boolean {
+        return !isTablet(context) &&
+                !isWearable(context) &&
+                !isAuto(context) &&
+                !isTv(context)
+    }
+
+    private fun isTablet(context: Context): Boolean {
+        val configuration = context.resources.configuration
+        val screenLayoutSize = configuration.screenLayout and SCREENLAYOUT_SIZE_MASK
+        val isXLarge = screenLayoutSize > SCREENLAYOUT_SIZE_LARGE
+
+        return isXLarge || isSevenInchTablet(context)
+    }
+
+    private fun isFoldable(context: Context): Boolean {
+        val sensorManager = context.getSystemService<SensorManager>()
+
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+                sensorManager?.getDefaultSensor(Sensor.TYPE_HINGE_ANGLE) != null
+    }
+
+    private fun isSevenInchTablet(context: Context): Boolean {
+        val configuration = context.resources.configuration
+        val screenLayoutSize = configuration.screenLayout and SCREENLAYOUT_SIZE_MASK
+
+        return screenLayoutSize <= SCREENLAYOUT_SIZE_LARGE &&
+                configuration.smallestScreenWidthDp >= SEVEN_INCH_TABLET_MINIMUM_SCREEN_WIDTH_DP
+    }
+
+    private fun isWearable(context: Context): Boolean {
+        return context.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)
+    }
+
+    private fun isAuto(context: Context): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+    }
+
+    private fun isTv(context: Context): Boolean {
+        val packageManager = context.packageManager
+
+        @Suppress("DEPRECATION")
+        return packageManager.hasSystemFeature(FEATURE_TV_1) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION) ||
+                packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+    }
+}

--- a/lib/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
+++ b/lib/src/main/java/ch/srgssr/androidx/mediarouter/compose/Icons.kt
@@ -1,7 +1,5 @@
 package ch.srgssr.androidx.mediarouter.compose
 
-import androidx.compose.material.icons.materialIcon
-import androidx.compose.material.icons.materialPath
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor

--- a/lib/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialog.kt
+++ b/lib/src/main/java/ch/srgssr/androidx/mediarouter/compose/MediaRouteChooserDialog.kt
@@ -259,13 +259,14 @@ private fun ColumnScope.NoDevicesNoWifiHint() {
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val context = LocalContext.current
+
         Icon(
             imageVector = Icons.Wifi,
             contentDescription = stringResource(R.string.ic_media_route_learn_more_accessibility),
         )
 
-        // TODO Handle every device type (see DeviceUtils.getDialogChooserWifiWarningDescription())
-        Text(text = stringResource(R.string.mr_chooser_wifi_warning_description_unknown))
+        Text(text = DeviceUtils.getDialogChooserWifiWarningDescription(context))
     }
 
     LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
@@ -283,10 +284,10 @@ private fun ColumnScope.NoRoutes() {
         )
 
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            val context = LocalContext.current
             val uriHandler = LocalUriHandler.current
 
-            // TODO Handle every device type (see DeviceUtils.getDialogChooserWifiWarningDescription())
-            Text(text = stringResource(R.string.mr_chooser_wifi_warning_description_unknown))
+            Text(text = DeviceUtils.getDialogChooserWifiWarningDescription(context))
 
             LearnMoreLink(
                 url = "https://support.google.com/chromecast/?p=trouble-finding-devices",

--- a/lib/src/test/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtilsTest.kt
+++ b/lib/src/test/java/ch/srgssr/androidx/mediarouter/compose/DeviceUtilsTest.kt
@@ -1,0 +1,157 @@
+package ch.srgssr.androidx.mediarouter.compose
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.os.Build
+import androidx.core.content.getSystemService
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSensor
+import java.util.Locale
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class DeviceUtilsTest {
+    private lateinit var context: Context
+
+    @BeforeTest
+    fun before() {
+        Locale.setDefault(Locale.ENGLISH)
+
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `getDialogChooserWifiWarningDescription phone`() {
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this phone",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    @Config(qualifiers = "xlarge")
+    fun `getDialogChooserWifiWarningDescription tablet`() {
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this tablet",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `getDialogChooserWifiWarningDescription foldable pre-R`() {
+        val sensorManager = context.getSystemService<SensorManager>()
+        val shadowSensorManager = shadowOf(sensorManager)
+        shadowSensorManager.addSensor(ShadowSensor.newInstance(Sensor.TYPE_HINGE_ANGLE))
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this phone",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun `getDialogChooserWifiWarningDescription foldable`() {
+        val sensorManager = context.getSystemService<SensorManager>()
+        val shadowSensorManager = shadowOf(sensorManager)
+        shadowSensorManager.addSensor(ShadowSensor.newInstance(Sensor.TYPE_HINGE_ANGLE))
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this phone",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    @Config(qualifiers = "sw600dp-large")
+    fun `getDialogChooserWifiWarningDescription 7 inches tablet`() {
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this tablet",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    fun `getDialogChooserWifiWarningDescription wearable`() {
+        val packageManger = context.packageManager
+        val shadowPackageManager = shadowOf(packageManger)
+        shadowPackageManager.setSystemFeature(PackageManager.FEATURE_WATCH, true)
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this watch",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.N_MR1])
+    fun `getDialogChooserWifiWarningDescription auto pre-O`() {
+        val packageManger = context.packageManager
+        val shadowPackageManager = shadowOf(packageManger)
+        shadowPackageManager.setSystemFeature(PackageManager.FEATURE_AUTOMOTIVE, true)
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this phone",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O])
+    fun `getDialogChooserWifiWarningDescription auto`() {
+        val packageManger = context.packageManager
+        val shadowPackageManager = shadowOf(packageManger)
+        shadowPackageManager.setSystemFeature(PackageManager.FEATURE_AUTOMOTIVE, true)
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this car",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    fun `getDialogChooserWifiWarningDescription TV 1`() {
+        val packageManger = context.packageManager
+        val shadowPackageManager = shadowOf(packageManger)
+        shadowPackageManager.setSystemFeature("com.google.android.tv", true)
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this tv",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    fun `getDialogChooserWifiWarningDescription TV 2`() {
+        val packageManger = context.packageManager
+        val shadowPackageManager = shadowOf(packageManger)
+        @Suppress("DEPRECATION")
+        shadowPackageManager.setSystemFeature(PackageManager.FEATURE_TELEVISION, true)
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this tv",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+
+    @Test
+    fun `getDialogChooserWifiWarningDescription TV 3`() {
+        val packageManger = context.packageManager
+        val shadowPackageManager = shadowOf(packageManger)
+        shadowPackageManager.setSystemFeature(PackageManager.FEATURE_LEANBACK, true)
+
+        assertEquals(
+            "Make sure the other device is on the same Wi-Fi network as this tv",
+            DeviceUtils.getDialogChooserWifiWarningDescription(context)
+        )
+    }
+}


### PR DESCRIPTION
This PR imports MediaRouter's internal `DeviceUtils` class and converts it to Kotlin. This allows showing a more specific warning message if no supported devices are found.