### PR TITLE
Fix the `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
       VERSION_NAME: ${{ github.ref_name }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,12 +27,8 @@ jobs:
         run: ./gradlew publish
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
-        permissions:
-          contents: write
-          discussions: write
         with:
           draft: true
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: lib/build/outputs/aar/mediarouter-compose-release.aar
-          discussion_category_name: 'announcements'


### PR DESCRIPTION
This moves the `permissions` block to the `job` level. It also removes the discussions setup. Since the release is a draft, it doesn't make sense to have it.