### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       VERSION_NAME: ${{ github.ref_name }}
     permissions:
       contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,4 +32,4 @@ jobs:
           draft: true
           generate_release_notes: true
           fail_on_unmatched_files: true
-          files: lib/build/outputs/aar/mediarouter-compose-release.aar
+          files: mediarouter-compose/build/outputs/aar/mediarouter-compose-release.aar


### PR DESCRIPTION
## Description

The `packages` permission was missing, and the path to the AAR file was wrong.

I've tested these changes on a fork of this repository to ensure that it finally works.

## Changes made

- Add the `packages: write` permission to the `release.yml` workflow.
- Fix the path to the AAR file attached to the GitHub Release.
