### PR TITLE
Add more information to the generated POM file

### DIFF
--- a/media-maestro/build.gradle.kts
+++ b/media-maestro/build.gradle.kts
@@ -159,6 +159,52 @@ publishing {
             afterEvaluate {
                 from(components["release"])
             }
+
+            pom {
+                name = "MediaMaestro"
+                description = "Seamless integration of AndroidX MediaRouter with Compose"
+                url = "https://github.com/SRGSSR/MediaMaestro"
+                inceptionYear = "2025"
+
+                licenses {
+                    license {
+                        name = "The MIT License"
+                        url = "https://opensource.org/licenses/MIT"
+                    }
+                }
+
+                organization {
+                    name = "SRG SSR"
+                    url = "https://www.srgssr.ch/"
+                }
+
+                scm {
+                    connection = "scm:git:git://github.com/SRGSSR/MediaMaestro.git"
+                    developerConnection = "scm:git:git@github.com:SRGSSR/MediaMaestro.git"
+                    url = "https://github.com/SRGSSR/MediaMaestro"
+                }
+
+                issueManagement {
+                    system = "GitHub Issues"
+                    url = "https://github.com/SRGSSR/MediaMaestro/issues"
+                }
+
+                ciManagement {
+                    system = "GitHub Actions"
+                    url = "https://github.com/SRGSSR/MediaMaestro/actions"
+                }
+
+                // TODO Simplify this once https://github.com/gradle/gradle/issues/28759 is released
+                withXml {
+                    asNode().appendNode("distributionManagement").apply {
+                        appendNode("repository").apply {
+                            appendNode("id", "github-packages")
+                            appendNode("name", "GitHub Packages")
+                            appendNode("url", "https://maven.pkg.github.com/SRGSSR/MediaMaestro")
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds more information to the generated POM file when publishing the library.

## Changes made

- Add the following information to the generated POM file:
  - Library name.
  - Library description.
  - Library URL.
  - Creation year.
  - License information.
  - Owning organisation.
  - Source control information.
  - Issue management.
  - CI information.
  - Target repository information.

## Result

Left: current generated POM file for version 0.10.0
Right: generated POM file from this branch

<img width="1331" alt="Screenshot 2025-06-12 at 21 29 45" src="https://github.com/user-attachments/assets/a11e46d8-41f1-4fb8-96fa-7fb8fecd54aa" />