### PR TITLE
Update to Detekt 2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,8 @@
  * License information is available from the LICENSE file.
  */
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.extensions.DetektExtension
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
@@ -20,14 +21,23 @@ plugins {
 }
 
 allprojects {
-    pluginManager.apply("io.gitlab.arturbosch.detekt")
+    pluginManager.apply(rootProject.libs.plugins.detekt.get().pluginId)
 
     extensions.configure<DetektExtension> {
-        basePath = projectDir.absolutePath
+        basePath.dir(projectDir.absolutePath)
         buildUponDefaultConfig = true
         config.setFrom(rootDir.resolve("config/detekt.yml"))
         ignoredBuildTypes = listOf("release")
         parallel = true
+    }
+
+    tasks.withType<Detekt>().configureEach {
+        reports {
+            checkstyle.required = false
+            html.required = true
+            markdown.required = false
+            sarif.required = true
+        }
     }
 
     afterEvaluate {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,8 @@
  * License information is available from the LICENSE file.
  */
 
-import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import dev.detekt.gradle.Detekt
+import dev.detekt.gradle.extensions.DetektExtension
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
@@ -19,14 +20,23 @@ plugins {
 }
 
 allprojects {
-    pluginManager.apply("io.gitlab.arturbosch.detekt")
+    pluginManager.apply(rootProject.libs.plugins.detekt.get().pluginId)
 
     extensions.configure<DetektExtension> {
-        basePath = projectDir.absolutePath
+        basePath.dir(projectDir.absolutePath)
         buildUponDefaultConfig = true
         config.setFrom(rootDir.resolve("config/detekt.yml"))
         ignoredBuildTypes = listOf("release")
         parallel = true
+    }
+
+    tasks.withType<Detekt>().configureEach {
+        reports {
+            checkstyle.required = false
+            html.required = true
+            markdown.required = false
+            sarif.required = true
+        }
     }
 
     afterEvaluate {

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,10 +1,3 @@
-output-reports:
-  active: true
-  exclude:
-    - 'MdOutputReport'
-    - 'TxtOutputReport'
-    - 'XmlOutputReport'
-
 comments:
   AbsentOrWrongFileLicense:
     active: true
@@ -46,5 +39,5 @@ style:
   MagicNumber:
     ignoreAnnotated: [ 'Composable' ]
 
-  UnusedPrivateMember:
+  UnusedPrivateFunction:
     ignoreAnnotated: [ 'Preview', 'PreviewLightDark' ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidx-test-core = "1.7.0"
 androidx-test-ext-junit = "1.3.0"
 coil = "3.4.0"
 dependency-analysis-gradle-plugin = "3.9.0"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"
 junit = "4.13.2"
 kotlin = "2.3.21"
@@ -86,7 +86,7 @@ android-application = { id = "com.android.application", version.ref = "android-g
 android-compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "android-compose-screenshot" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 dependency-analysis-gradle-plugin = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis-gradle-plugin" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidx-test-core = "1.7.0"
 androidx-test-ext-junit = "1.3.0"
 coil = "3.5.0"
 dependency-analysis-gradle-plugin = "3.18.0"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.6"
 dokka = "2.2.0"
 junit = "4.13.2"
 kotlin = "2.4.10"
@@ -86,7 +86,7 @@ android-application = { id = "com.android.application", version.ref = "android-g
 android-compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "android-compose-screenshot" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 dependency-analysis-gradle-plugin = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis-gradle-plugin" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
## Description

This PR updates Detekt to version 2.0.

## Changes made

- Update Detekt to 2.0.
- Migrate Detekt package name to `dev.detekt.gradle.*`.
- Migrate Detekt plugin id to `dev.detekt`.
- Migrate Detekt reports setup to Gradle.
- Rename the `UnusedPrivateMember` rule to `UnusedPrivateFunction`.

**Note:** this is a draft until Detekt 2.0 is stable.