### PR TITLE
Disable `OldTargetApi` Lint warning in `:demo`

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -47,6 +47,7 @@ android {
         disable.add("AndroidGradlePluginVersion")
         disable.add("GradleDependency")
         disable.add("NewerVersionAvailable")
+        disable.add("OldTargetApi")
         sarifReport = true
         warningsAsErrors = true
     }


### PR DESCRIPTION
## Description

The `OldTargetApi` Lint warning is triggered when we don't target the latest Android SDK version. This is only relevant in the `:demo`. I have disabled this warning so we can update it when we are ready, without blocking other PRs.

## Changes made

Self-explanatory.