### PR TITLE
Update to AGP 9.1.1

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -59,14 +59,14 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Detekt
-        run: ./gradlew detektDebug
+        run: ./gradlew detekt
       - name: Upload Detekt results
         uses: github/codeql-action/upload-sarif@v4
         # Don't upload results from the merge queue.
         # See https://github.com/github/codeql-action/issues/1572
         if: (! startsWith(github.ref, 'refs/heads/gh-readonly-queue')) && (success() || failure())
         with:
-          sarif_file: demo/build/reports/detekt/debug.sarif
+          sarif_file: demo/build/reports/detekt/detekt.sarif
           category: detekt
 
   unit-test:
@@ -218,6 +218,7 @@ jobs:
   binary-compatibility-validator:
     name: Binary Compatibility Validator
     runs-on: ubuntu-latest
+    if: false # Plugin not compatible with AGP 9: https://github.com/Kotlin/binary-compatibility-validator/issues/312
     permissions:
       contents: write
     env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.dokka.javadoc) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlinx.binary.compatibility.validator)
     alias(libs.plugins.kotlinx.kover)
@@ -66,9 +65,9 @@ subprojects {
 apiValidation {
     ignoredProjects.add("demo")
     // See https://github.com/Kotlin/binary-compatibility-validator/issues/74
-    ignoredClasses.add("ch.srgssr.media.maestro.ComposableSingletons\$CastIconKt")
-    ignoredClasses.add("ch.srgssr.media.maestro.ComposableSingletons\$MediaRouteChooserDialogKt")
-    ignoredClasses.add("ch.srgssr.media.maestro.ComposableSingletons\$MediaRouteControllerDialogKt")
+    ignoredClasses.add($$"ch.srgssr.media.maestro.ComposableSingletons$CastIconKt")
+    ignoredClasses.add($$"ch.srgssr.media.maestro.ComposableSingletons$MediaRouteChooserDialogKt")
+    ignoredClasses.add($$"ch.srgssr.media.maestro.ComposableSingletons$MediaRouteControllerDialogKt")
 }
 
 dokka {

--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 
@@ -36,8 +35,6 @@ android {
 
     buildFeatures {
         compose = true
-        resValues = false
-        shaders = false
     }
 
     lint {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-compose-screenshot = "0.0.1-alpha14"
-android-gradle-plugin = "8.13.2"
+android-gradle-plugin = "9.1.1"
 androidx-activity = "1.13.0"
 androidx-annotation = "1.10.0"
 androidx-annotation-experimental = "1.6.0"
@@ -73,6 +73,7 @@ coil-core = { group = "io.coil-kt.coil3", name = "coil-core", version.ref = "coi
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 play-services-cast-framework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "play-services-cast-framework" }
@@ -89,7 +90,6 @@ dependency-analysis-gradle-plugin = { id = "com.autonomousapps.dependency-analys
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility-validator" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover" }

--- a/media-maestro/build.gradle.kts
+++ b/media-maestro/build.gradle.kts
@@ -11,7 +11,6 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.dokka)
     alias(libs.plugins.dokka.javadoc)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.maven.publish)
@@ -24,7 +23,6 @@ android {
 
     defaultConfig {
         minSdk = 23
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -40,8 +38,6 @@ android {
 
     buildFeatures {
         compose = true
-        resValues = false
-        shaders = false
     }
 
     lint {
@@ -142,6 +138,7 @@ dependencies {
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)

--- a/media-maestro/src/test/java/ch/srgssr/media/maestro/MediaRouteButtonTest.kt
+++ b/media-maestro/src/test/java/ch/srgssr/media/maestro/MediaRouteButtonTest.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.core.content.getSystemService
 import androidx.mediarouter.media.MediaRouter
 import androidx.mediarouter.testing.MediaRouterTestHelper

--- a/media-maestro/src/test/java/ch/srgssr/media/maestro/MediaRouteControllerDialogViewModelTest.kt
+++ b/media-maestro/src/test/java/ch/srgssr/media/maestro/MediaRouteControllerDialogViewModelTest.kt
@@ -63,6 +63,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
+@Suppress("LargeClass")
 class MediaRouteControllerDialogViewModelTest(
     private val volumeControlEnabled: Boolean,
 ) {


### PR DESCRIPTION
## Description

This PR updates the project to AGP 9.1.1 (from 8.13.2).

## Changes made

- Update AGP to 9.1.1.
- Migrate to [built-in Kotlin](https://developer.android.com/build/migrate-to-built-in-kotlin).
- Add the missing `kotlin-test-junit` dependency.
- Fix the Detekt task to use `detekt` instead of `detektDebug` (which no longer exists).
- Remove properties that now match their default value:
  - `android.buildFeatures.resValues`.
  - `android.buildFeatures.shaders`.
  - `android.defaultConfig.testInstrumentationRunner`.

## Note

- The latest version is AGP 9.2.1. But updating to it triggers an error, so I'm sticking to 9.1.1 for now.
- The Binary Compatibility Validator plugin is not yet compatible with AGP 9+ (see https://github.com/Kotlin/binary-compatibility-validator/issues/312). So I've disabled that step for now.
- This partially replaces #208.